### PR TITLE
Minor update to the examples

### DIFF
--- a/examples/06_parachain_overrides.yml
+++ b/examples/06_parachain_overrides.yml
@@ -16,8 +16,9 @@ jobs:
         env:
           # optional: will override the parachain pallet ID and authorize_upgrade call ID,
           #           which will result in a different parachain_authorize_upgrade_hash
-          PARACHAIN_PALLET_ID: 0x1e
-          AUTHORIZE_UPGRADE_PREFIX: 0x02
+          # the hex values must be quoted
+          PARACHAIN_PALLET_ID: "0x1e"
+          AUTHORIZE_UPGRADE_PREFIX: "0x02"
         with:
           chain: ${{ matrix.chain }}
           runtime_dir: polkadot-parachains/${{ matrix.chain }}-runtime


### PR DESCRIPTION
The env hex values must be quoted, otherwise GHA will automatically translate it to decimal before further processing