### PR TITLE
Add moonbeam/moonriver for testing

### DIFF
--- a/.github/workflows/cumulus.yml
+++ b/.github/workflows/cumulus.yml
@@ -5,11 +5,9 @@ env:
 
 on:
   pull_request:
-    branches:
-      - master
+    types: [opened, reopened, synchronize]
+
   push:
-    branches:
-      - "*"
     tags:
       - "v*"
 

--- a/.github/workflows/cumulus.yml
+++ b/.github/workflows/cumulus.yml
@@ -10,6 +10,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - master
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/moonbeam.yml
+++ b/.github/workflows/moonbeam.yml
@@ -1,0 +1,90 @@
+name: Manual Build - Moonbeam
+
+env:
+  SUBWASM_VERSION: 0.20.0
+
+on:
+  workflow_dispatch:
+    inputs:
+      srtool_tag:
+        description: The SRTOOL tag to use
+        default: 1.70.0
+        required: false
+      ref:
+        description: The ref to be used for the repo
+        default: master
+        required: false
+
+jobs:
+  build:
+    name: Build ${{ matrix.chain }} ${{ github.event.inputs.ref }}
+    strategy:
+      matrix:
+        chain: ["moonriver"]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: PureStake/moonbeam
+          ref: ${{ github.event.inputs.ref }}
+          fetch-depth: 0
+
+    # We now get extra information thanks to subwasm,
+      - name: Install subwasm ${{ env.SUBWASM_VERSION }}
+        run: |
+            wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+            sudo dpkg -i subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb
+            subwasm --version
+
+      - name: Srtool build
+        id: srtool_build
+        uses: ./action
+        with:
+          chain: ${{ matrix.chain }}
+          tag: ${{ github.event.inputs.srtool_tag }}
+
+      - name: Summary
+        run: |
+          echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.chain }}-srtool-digest.json
+          cat ${{ matrix.chain }}-srtool-digest.json
+          echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
+
+      # it takes a while to build the runtime, so let's save the artifact as soon as we have it
+      - name: Archive Artifacts for ${{ matrix.chain }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.chain }}-runtime
+          path: |
+            ${{ steps.srtool_build.outputs.wasm }}
+            ${{ steps.srtool_build.outputs.wasm_compressed }}
+            ${{ matrix.chain }}-srtool-digest.json
+
+      - name: Show Runtime information
+        env:
+            RUST_LOG: subwasm=debug
+        run: |
+          subwasm info ${{ steps.srtool_build.outputs.wasm }}
+          subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}
+          subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.chain }}-info.json
+          subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ matrix.chain }}-info_compressed.json
+
+      - name: Extract the metadata
+        run: |
+          subwasm meta ${{ steps.srtool_build.outputs.wasm }}
+          subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.chain }}-metadata.json
+
+      - name: Check the metadata diff
+        run: |
+          # subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} | tee ${{ matrix.chain }}-diff.txt
+          echo "No live chain to compare" > ${{ matrix.chain }}-diff.txt
+
+      - name: Archive Subwasm results
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: ${{ matrix.chain }}-runtime
+          path: |
+            ${{ matrix.chain }}-info.json
+            ${{ matrix.chain }}-info_compressed.json
+            ${{ matrix.chain }}-metadata.json
+            ${{ matrix.chain }}-diff.txt

--- a/.github/workflows/moonbeam.yml
+++ b/.github/workflows/moonbeam.yml
@@ -2,6 +2,7 @@ name: Manual Build - Moonbeam
 
 env:
   SUBWASM_VERSION: 0.20.0
+  RUST_LOG: subwasm=debug
 
 on:
   workflow_dispatch:
@@ -61,8 +62,6 @@ jobs:
             ${{ matrix.chain }}-srtool-digest.json
 
       - name: Show Runtime information
-        env:
-            RUST_LOG: subwasm=debug
         run: |
           subwasm info ${{ steps.srtool_build.outputs.wasm }}
           subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}

--- a/.github/workflows/moonbeam.yml
+++ b/.github/workflows/moonbeam.yml
@@ -28,8 +28,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: PureStake/moonbeam
-          ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
+          path: repo
+          ref: ${{ github.event.inputs.ref }}
 
     # We now get extra information thanks to subwasm,
       - name: Install subwasm ${{ env.SUBWASM_VERSION }}
@@ -42,8 +43,9 @@ jobs:
         id: srtool_build
         uses: ./action
         with:
-          chain: ${{ matrix.chain }}
           tag: ${{ github.event.inputs.srtool_tag }}
+          chain: ${{ matrix.chain }}
+          workdir: "${{ github.workspace }}/repo"
 
       - name: Summary
         run: |

--- a/.github/workflows/moonbeam.yml
+++ b/.github/workflows/moonbeam.yml
@@ -27,12 +27,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          path: action
+
+      - uses: actions/checkout@v3
+        with:
           repository: PureStake/moonbeam
           fetch-depth: 0
           path: repo
           ref: ${{ github.event.inputs.ref }}
 
-    # We now get extra information thanks to subwasm,
+      # We now get extra information thanks to subwasm,
       - name: Install subwasm ${{ env.SUBWASM_VERSION }}
         run: |
             wget https://github.com/chevdor/subwasm/releases/download/v${{ env.SUBWASM_VERSION }}/subwasm_linux_amd64_v${{ env.SUBWASM_VERSION }}.deb

--- a/.github/workflows/polkadot.yml
+++ b/.github/workflows/polkadot.yml
@@ -5,11 +5,9 @@ env:
 
 on:
   pull_request:
-    branches:
-      - master
+    types: [opened, reopened, synchronize]
+
   push:
-    branches:
-      - "*"
     tags:
       - "v*"
 

--- a/.github/workflows/polkadot.yml
+++ b/.github/workflows/polkadot.yml
@@ -10,6 +10,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - master
 
   workflow_dispatch:
     inputs:

--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,8 @@ inputs:
   workdir:
     description: >
       Path of the project, this is where your main Cargo.toml is located. This is relative to $GITHUB_WORKSPACE.
-
-    required: true
+    default: "."
+    required: false
 
   runtime_dir:
     description: >


### PR DESCRIPTION
I spotted issues building Moonriver. 

This PR:
- adds a new workflow to test Moonriver manually (workflow_dispatch)
- allows NOT providing `workdir` (as done in many places)
- fix double CI runs when pushing to a PR branch